### PR TITLE
minor: api key now optional in support of allowlist security update

### DIFF
--- a/.changeset/deep-swans-leave.md
+++ b/.changeset/deep-swans-leave.md
@@ -1,0 +1,6 @@
+---
+"@amarsia/react": minor
+"@amarsia/sdk": minor
+---
+
+Allow keyless SDK calls for public workflows and improve error handling so users get clear status/code/message across run/stream/conversation methods.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -46,7 +46,9 @@ import { amarsia } from "@amarsia/sdk";
 import { useConversation } from "@amarsia/react";
 
 const client = amarsia.init({
-  apiKey: process.env.NEXT_PUBLIC_AMARSIA_API_KEY!,
+  // apiKey is optional. Omit it for public workflows (authentication off)
+  // where requests are authorized by the workflow's allowlist instead.
+  apiKey: process.env.NEXT_PUBLIC_AMARSIA_API_KEY,
   deploymentId: process.env.NEXT_PUBLIC_AMARSIA_DEPLOYMENT_ID!
 });
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amarsia/react",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "The official React and Next.js SDK wrapper for Amarsia — build AI assistants with stateful hooks.",
   "license": "MIT",
   "author": "Amarsia",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -54,12 +54,29 @@ console.log(client.run.meta); // token/model metadata when available
 import { amarsia } from "@amarsia/sdk";
 
 const client = amarsia.init({
-  apiKey: "YOUR_API_KEY", // required
+  apiKey: "YOUR_API_KEY", // optional; required only when the workflow has authentication enabled
   deploymentId: "dep_123", // optional default deployment for all calls
   baseUrl: "https://api.amarsia.com", // optional, defaults to this
   dangerouslyAllowBrowserApiKey: true // optional browser risk acknowledgment
 });
 ```
+
+### Public (auth-less) workflows
+
+If a workflow has **Authentication** turned off in the dashboard, you can
+call it without an API key. The request is authorized by the workflow's
+**Allowlist** based on the browser's `Origin` / `Referer`, so the
+initialization can simply omit `apiKey`:
+
+```ts
+const client = amarsia.init({
+  deploymentId: "dep_123"
+});
+```
+
+When `apiKey` is omitted, the SDK will not send the `x-api-key` header.
+If the workflow still requires authentication server-side, the API will
+return a 401.
 
 ### Deployment ID behavior
 
@@ -217,7 +234,7 @@ For React/Next usage, use [@amarsia/react](https://www.npmjs.com/package/@amarsi
 
 ```ts
 type InitConfig = {
-  apiKey: string;
+  apiKey?: string;
   deploymentId?: string;
   baseUrl?: string;
   dangerouslyAllowBrowserApiKey?: boolean;
@@ -346,7 +363,7 @@ See full examples and endpoint docs at [docs.amarsia.com](https://docs.amarsia.c
 
 ## Error handling
 
-SDK methods throw `AmarsiaSdkError` with normalized fields.
+Every SDK method (`run`, `stream`, `conversation.run`, `conversation.stream`, `conversation.loadMessages`, `conversation.list`) throws `AmarsiaSdkError` on failure with normalized fields.
 
 ```ts
 import { AmarsiaSdkError } from "@amarsia/sdk";
@@ -357,12 +374,62 @@ try {
   });
 } catch (error) {
   if (error instanceof AmarsiaSdkError) {
-    console.error(error.name, error.message, error.status, error.code);
+    console.error(error.name);    // e.g. "AmarsiaHttpError"
+    console.error(error.status);  // HTTP status, e.g. 401
+    console.error(error.code);    // stable string code, e.g. "unauthorized"
+    console.error(error.message); // human-readable message from the API
   } else {
     console.error(error);
   }
 }
 ```
+
+### Error field reference
+
+| Field | Description |
+|---|---|
+| `name` | Error class name: `AmarsiaHttpError`, `AmarsiaValidationError`, `AmarsiaConfigurationError`, `AmarsiaAbortError`, `AmarsiaNetworkError`. |
+| `status` | HTTP status for API errors. `undefined` for SDK-side errors. |
+| `code` | Stable symbolic code you can switch on. For HTTP errors derived from the status when the API doesn't send one. |
+| `message` | Human-readable message, extracted from the API response. |
+| `details` | The full response body (parsed) or raw string. |
+
+### Common codes
+
+| `code` | Typical cause |
+|---|---|
+| `bad_request` | Malformed payload or unknown deployment id. |
+| `unauthorized` | API key is required, invalid, expired, or for the wrong project. |
+| `forbidden` | The workflow is public but the request origin is not in its allowlist. |
+| `not_found` | The workflow or resource does not exist. |
+| `unprocessable_entity` | Request body failed server-side validation (FastAPI 422). |
+| `rate_limited` | Usage or action rate limits exceeded. |
+| `internal_server_error` | Unhandled error on the server. |
+
+### Example: branching on `code`
+
+```ts
+try {
+  await client.run({ content: [{ type: "text", text: "Hello" }] });
+} catch (error) {
+  if (!(error instanceof AmarsiaSdkError)) throw error;
+
+  switch (error.code) {
+    case "unauthorized":
+      // Missing or invalid apiKey for a workflow that requires authentication.
+      break;
+    case "forbidden":
+      // Public workflow, but the current origin is not on the allowlist.
+      break;
+    default:
+      throw error;
+  }
+}
+```
+
+### Controller state
+
+Every controller (`client.run`, `client.stream`, `client.conversation`) also mirrors the error on its state, so UIs that subscribe to `getState()` / `subscribe(...)` get `status === "error"` and the same `AmarsiaSdkErrorData` on `.error` without needing a try/catch.
 
 ## Security guidance
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amarsia/sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "The official JavaScript and TypeScript SDK for Amarsia — run, stream, and manage AI assistants.",
   "license": "MIT",
   "author": "Amarsia",

--- a/packages/sdk/src/core/http.ts
+++ b/packages/sdk/src/core/http.ts
@@ -1,7 +1,8 @@
 import { createConfigError, createValidationError, fromHttpError, wrapUnknownError } from "../errors";
 import type { ApiErrorEnvelope, InitConfig } from "../types";
 
-type HttpClientConfig = Required<Pick<InitConfig, "apiKey" | "fetch">> & {
+type HttpClientConfig = Required<Pick<InitConfig, "fetch">> & {
+  apiKey?: string;
   baseUrl: string;
   deploymentId?: string;
   dangerouslyAllowBrowserApiKey?: boolean;
@@ -19,10 +20,7 @@ type RequestOptions = {
 let hasWarnedBrowserApiKey = false;
 
 export function createHttpClient(config: InitConfig): HttpClientConfig {
-  const apiKey = config.apiKey.trim();
-  if (!apiKey) {
-    throw createConfigError("`apiKey` is required in amarsia.init(...).");
-  }
+  const apiKey = config.apiKey?.trim();
 
   const fetchImpl = config.fetch ?? globalThis.fetch;
   if (typeof fetchImpl !== "function") {
@@ -30,13 +28,18 @@ export function createHttpClient(config: InitConfig): HttpClientConfig {
   }
 
   const baseUrl = normalizeBaseUrl(config.baseUrl ?? "https://api.amarsia.com");
-  warnForBrowserApiKey(config.dangerouslyAllowBrowserApiKey);
+  if (apiKey) {
+    warnForBrowserApiKey(config.dangerouslyAllowBrowserApiKey);
+  }
 
   const client: HttpClientConfig = {
-    apiKey,
     fetch: fetchImpl,
     baseUrl
   };
+
+  if (apiKey) {
+    client.apiKey = apiKey;
+  }
 
   if (config.deploymentId !== undefined) {
     client.deploymentId = config.deploymentId;
@@ -162,13 +165,18 @@ async function request(client: HttpClientConfig, options: RequestOptions): Promi
   const query = buildQuery(options.query);
   const url = `${client.baseUrl}${options.path}${query}`;
 
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...options.headers
+  };
+
+  if (client.apiKey) {
+    headers["x-api-key"] = client.apiKey;
+  }
+
   const init: RequestInit = {
     method: options.method ?? "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-api-key": client.apiKey,
-      ...options.headers
-    }
+    headers
   };
 
   if (options.signal !== undefined) {

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -81,23 +81,122 @@ export function fromHttpError(
   envelope: ApiErrorEnvelope | null,
   fallbackBody?: string
 ): AmarsiaSdkError {
-  const payload = envelope?.error;
-  const message = payload?.message ?? fallbackBody ?? `Request failed with status ${status} ${statusText}`.trim();
+  const parsed = parseErrorEnvelope(envelope);
+  const message =
+    parsed.message ??
+    (typeof fallbackBody === "string" && fallbackBody.trim() !== "" && !looksLikeJsonObject(fallbackBody)
+      ? fallbackBody
+      : `Request failed with status ${status} ${statusText}`.trim());
 
   const data: AmarsiaSdkErrorData = {
     name: "AmarsiaHttpError",
     message,
-    status
+    status,
+    code: parsed.code ?? statusToCode(status)
   };
 
-  if (payload?.type !== undefined) data.type = payload.type;
-  if (payload?.code !== undefined) data.code = payload.code;
-  if (payload?.param !== undefined) data.param = payload.param;
+  if (parsed.type !== undefined) data.type = parsed.type;
+  if (parsed.param !== undefined) data.param = parsed.param;
 
   const details = envelope ?? fallbackBody;
   if (details !== undefined) data.details = details;
 
   return new AmarsiaSdkError(data);
+}
+
+type ParsedEnvelope = {
+  message?: string;
+  code?: string | null;
+  type?: string;
+  param?: string | null;
+};
+
+function parseErrorEnvelope(envelope: ApiErrorEnvelope | null): ParsedEnvelope {
+  if (!envelope) {
+    return {};
+  }
+
+  const openai = envelope.error;
+  if (openai && typeof openai === "object") {
+    const parsed: ParsedEnvelope = {};
+    if (typeof openai.message === "string") parsed.message = openai.message;
+    if (openai.code !== undefined) parsed.code = openai.code;
+    if (typeof openai.type === "string") parsed.type = openai.type;
+    if (openai.param !== undefined) parsed.param = openai.param;
+    if (parsed.message !== undefined) return parsed;
+  }
+
+  const detail = envelope.detail;
+  if (typeof detail === "string" && detail.trim() !== "") {
+    return { message: detail };
+  }
+
+  if (Array.isArray(detail) && detail.length > 0) {
+    const first = detail[0];
+    const field = Array.isArray(first?.loc) ? first.loc.filter((p) => typeof p === "string").join(".") : "";
+    const msg = typeof first?.msg === "string" ? first.msg : undefined;
+    const message = field ? (msg ? `${field}: ${msg}` : field) : msg;
+    const parsed: ParsedEnvelope = {};
+    if (message) parsed.message = message;
+    if (typeof first?.type === "string") parsed.type = first.type;
+    if (field) parsed.param = field;
+    return parsed;
+  }
+
+  if (detail && typeof detail === "object") {
+    const parsed: ParsedEnvelope = {};
+    const msg = (detail as Record<string, unknown>).message;
+    const code = (detail as Record<string, unknown>).code;
+    const type = (detail as Record<string, unknown>).type;
+    if (typeof msg === "string") parsed.message = msg;
+    if (typeof code === "string" || code === null) parsed.code = code as string | null;
+    if (typeof type === "string") parsed.type = type;
+    return parsed;
+  }
+
+  return {};
+}
+
+function statusToCode(status: number): string {
+  switch (status) {
+    case 400:
+      return "bad_request";
+    case 401:
+      return "unauthorized";
+    case 402:
+      return "payment_required";
+    case 403:
+      return "forbidden";
+    case 404:
+      return "not_found";
+    case 408:
+      return "request_timeout";
+    case 409:
+      return "conflict";
+    case 413:
+      return "payload_too_large";
+    case 422:
+      return "unprocessable_entity";
+    case 429:
+      return "rate_limited";
+    case 500:
+      return "internal_server_error";
+    case 502:
+      return "bad_gateway";
+    case 503:
+      return "service_unavailable";
+    case 504:
+      return "gateway_timeout";
+    default:
+      if (status >= 500) return "server_error";
+      if (status >= 400) return "http_error";
+      return "http_error";
+  }
+}
+
+function looksLikeJsonObject(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.startsWith("{") || trimmed.startsWith("[");
 }
 
 export function wrapUnknownError(error: unknown): AmarsiaSdkError {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -32,6 +32,9 @@ export type UsageMetadata = {
 };
 
 export type ApiErrorEnvelope = {
+  /**
+   * OpenAI-style error envelope.
+   */
   error?: {
     type?: string;
     message?: string;
@@ -39,6 +42,25 @@ export type ApiErrorEnvelope = {
     code?: string | null;
     [key: string]: unknown;
   };
+  /**
+   * FastAPI-style error envelope. Plain HTTPException serializes to
+   * `{ detail: "string" }`; validation errors serialize to
+   * `{ detail: [{ msg, loc, type, ... }, ...] }`.
+   */
+  detail?:
+    | string
+    | {
+        message?: string;
+        code?: string | null;
+        type?: string;
+        [key: string]: unknown;
+      }
+    | Array<{
+        msg?: string;
+        type?: string;
+        loc?: Array<string | number>;
+        [key: string]: unknown;
+      }>;
   [key: string]: unknown;
 };
 
@@ -161,7 +183,12 @@ export type ConversationState = StatefulResult<ConversationData> & {
 };
 
 export type InitConfig = {
-  apiKey: string;
+  /**
+   * Optional. Required only when the target workflow has authentication
+   * enabled server-side. Public workflows (authentication turned off) can
+   * be called without an API key and are authorized by their allowlist.
+   */
+  apiKey?: string;
   deploymentId?: string;
   baseUrl?: string;
   dangerouslyAllowBrowserApiKey?: boolean;


### PR DESCRIPTION
Allow keyless SDK calls for public workflows and improve error handling so users get clear status/code/message across run/stream/conversation methods.